### PR TITLE
Improve sub oscillator quality

### DIFF
--- a/src/MonoSynth/index.tsx
+++ b/src/MonoSynth/index.tsx
@@ -28,13 +28,13 @@ export default function MonoSynth(): JSX.Element {
   const fft = useMemo(() => new Tone.FFT(1024), [])
   const waveform = useMemo(() => new Tone.Waveform(2048), [])
   const subOscillator = useMemo(
-    () => new Tone.Oscillator({ type: 'square' }),
-    []
+    () => new Tone.Oscillator({ type: 'sine', context: synth.context }),
+    [synth.context]
   )
   const [subOscEnabled, setSubOscEnabled] = useState(false)
   const subSubOscillator = useMemo(
-    () => new Tone.Oscillator({ type: 'sine' }),
-    []
+    () => new Tone.Oscillator({ type: 'sine', context: synth.context }),
+    [synth.context]
   )
   const [subSubOscEnabled, setSubSubOscEnabled] = useState(false)
 
@@ -55,7 +55,7 @@ export default function MonoSynth(): JSX.Element {
 
   const triggerAttack = useCallback(
     (note: string | number | Tone.FrequencyClass<number>) => {
-      const now = Tone.now()
+      const now = synth.now()
       synth.triggerAttack(note, now)
       pitchEnvelope.triggerAttack(now)
 
@@ -122,8 +122,9 @@ export default function MonoSynth(): JSX.Element {
     }
 
     return () => {
+      subOscillator.disconnect()
+      subSubOscillator.disconnect()
       synth.disconnect()
-
       synth.toDestination()
     }
   }, [

--- a/src/MonoSynth/index.tsx
+++ b/src/MonoSynth/index.tsx
@@ -27,7 +27,15 @@ export default function MonoSynth(): JSX.Element {
   const synth = useMemo(() => new Tone.MonoSynth().toDestination(), [])
   const fft = useMemo(() => new Tone.FFT(1024), [])
   const waveform = useMemo(() => new Tone.Waveform(2048), [])
+  const subOscillator = useMemo(
+    () => new Tone.Oscillator({ type: 'square' }),
+    []
+  )
   const [subOscEnabled, setSubOscEnabled] = useState(false)
+  const subSubOscillator = useMemo(
+    () => new Tone.Oscillator({ type: 'sine' }),
+    []
+  )
   const [subSubOscEnabled, setSubSubOscEnabled] = useState(false)
 
   const detuneLFO = useMemo(
@@ -47,22 +55,35 @@ export default function MonoSynth(): JSX.Element {
 
   const triggerAttack = useCallback(
     (note: string | number | Tone.FrequencyClass<number>) => {
-      synth.triggerAttack(note)
-      pitchEnvelope.triggerAttack()
+      const now = Tone.now()
+      synth.triggerAttack(note, now)
+      pitchEnvelope.triggerAttack(now)
+
+      // Set frequencies for sub oscillators
+      const freq = Tone.Frequency(note).toFrequency()
+      subOscillator.frequency.setValueAtTime(freq / 2, now)
+      subOscillator.start(now)
+      subSubOscillator.frequency.setValueAtTime(freq / 4, now)
+      subSubOscillator.start(now)
     },
-    [synth, pitchEnvelope]
+    [synth, subOscillator, subSubOscillator, pitchEnvelope]
   )
 
   const triggerRelease = useCallback(() => {
     synth.triggerRelease()
+    subOscillator.stop()
+    subSubOscillator.stop()
     pitchEnvelope.triggerRelease()
-  }, [synth, pitchEnvelope])
+  }, [synth, subOscillator, subSubOscillator, pitchEnvelope])
 
   const changeFrequency = useCallback(
     (hz: number) => {
-      synth.oscillator.frequency.setValueAtTime(hz, Tone.now())
+      const now = Tone.now()
+      synth.oscillator.frequency.setValueAtTime(hz, now)
+      subOscillator.frequency.setValueAtTime(hz / 2, now)
+      subSubOscillator.frequency.setValueAtTime(hz / 4, now)
     },
-    [synth.oscillator]
+    [synth.oscillator, subOscillator, subSubOscillator]
   )
 
   const formatDetune = useCallback(
@@ -93,34 +114,27 @@ export default function MonoSynth(): JSX.Element {
     synth.connect(waveform)
     synth.toDestination()
 
-    const subOscPitchShift = new Tone.PitchShift({
-      pitch: -12,
-      context: synth.context,
-    })
-    const subSubOscPitchShift = new Tone.PitchShift({
-      pitch: -24,
-      context: synth.context,
-    })
-
     if (subOscEnabled) {
-      synth.chain(subOscPitchShift, Tone.Destination)
-      subOscPitchShift.connect(fft)
-      subOscPitchShift.connect(waveform)
+      subOscillator.connect(synth.filter)
     }
     if (subSubOscEnabled) {
-      synth.chain(subSubOscPitchShift, Tone.Destination)
-      subSubOscPitchShift.connect(fft)
-      subSubOscPitchShift.connect(waveform)
+      subSubOscillator.connect(synth.filter)
     }
 
     return () => {
       synth.disconnect()
-      subOscPitchShift.disconnect().dispose()
-      subSubOscPitchShift.disconnect().dispose()
 
       synth.toDestination()
     }
-  }, [synth, fft, waveform, subOscEnabled, subSubOscEnabled])
+  }, [
+    synth,
+    fft,
+    waveform,
+    subOscillator,
+    subSubOscillator,
+    subOscEnabled,
+    subSubOscEnabled,
+  ])
 
   return (
     <div className={cs.synthContainer}>


### PR DESCRIPTION
Tonejs's [PitchShift](https://tonejs.github.io/docs/14.7.58/PitchShift) component introduces a lot of noise, since it is only capable of _near_ real time pitch shifting. In order to get consistent sub oscillator quality, in this PR we switch to using explicit `Oscillator` objects for each of the sub oscillators. Currently, both are `sine` oscillators.

This is still not ideal, since if you play the same note multiple times, you can hear different tone characteristics. The running theory is that this is due to the oscillators not starting at the same time, even though I pass in an explicit `time` value to all methods.